### PR TITLE
feat:各都道府県名データのフェッチ

### DIFF
--- a/src/app/lib/fetcher.ts
+++ b/src/app/lib/fetcher.ts
@@ -1,0 +1,7 @@
+export async function fetcher(path: string, option?: RequestInit) {
+  const apiServerUrl = process.env.NEXT_PUBLIC_API_SERVER_URL;
+  const href = new URL(path, apiServerUrl);
+  const response = await fetch(href, option);
+  const json = await response.json();
+  return json;
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,21 @@
+import { fetcher } from "./lib/fetcher";
 import SelectPref from "./ui/checkbox/SelectPref";
 import Header from "./ui/common/Header";
 
-export default function Home() {
+export default async function Home() {
+  const res = await fetcher("/api/v1/prefectures", {
+    headers: {
+      "X-API-KEY": process.env.NEXT_PUBLIC_API_KEY ?? "",
+      "Content-Type": "application/json; charset=UTF-8",
+    },
+    next: {
+      revalidate: 3600,
+    },
+  });
   return (
     <main>
       <Header />
-      <SelectPref />
+      <SelectPref prefs={res.result} />
     </main>
   );
 }

--- a/src/app/ui/checkbox/SelectPref.tsx
+++ b/src/app/ui/checkbox/SelectPref.tsx
@@ -1,22 +1,13 @@
 "use client";
 import { Prefecture } from "@/app/type/types";
 import { useCheckBoxList } from "./useCheckBox";
-const data: Prefecture[] = [
-  {
-    prefCode: 1,
-    prefName: "北海道",
-  },
-  {
-    prefCode: 2,
-    prefName: "青森県",
-  },
-  {
-    prefCode: 3,
-    prefName: "岩手県",
-  },
-];
-export default function SelectPref() {
-  const renderCheckBoxList = useCheckBoxList(data);
+
+type Props = {
+  prefs: Prefecture[];
+};
+
+export default function SelectPref({ prefs }: Props) {
+  const renderCheckBoxList = useCheckBoxList(prefs);
   return (
     <div className="w-1/2 mx-auto mt-2">
       <h2 className="text-xl font-bold mb-2">都道府県を選択</h2>

--- a/src/app/ui/checkbox/useCheckBox.tsx
+++ b/src/app/ui/checkbox/useCheckBox.tsx
@@ -6,9 +6,7 @@ import { Prefecture } from "../../type/types";
 type UseChecksResult = () => JSX.Element;
 
 export const useCheckBoxList = (prefs: Prefecture[]): UseChecksResult => {
-  const [checkBoxList, setCheckBoxList] = useState(() =>
-    prefs.map(() => false),
-  );
+  const [checkBoxList, setCheckBoxList] = useState(prefs.map(() => false));
 
   const handleCheckClick = (index: number) => {
     setCheckBoxList((checks) =>


### PR DESCRIPTION
### プルリクの目的
- 各都道府県のデータのフェッチ実装

### やったこと
- サーバーコンポーネントにおける各都道府県名データのフェッチ([参考](https://nextjs.org/docs/app/building-your-application/data-fetching/fetching))
- 都道府県データの型を追加

### 備考
- キャッシュは3600sと現在は設定している
- 各県の特徴データを取得する際にコンポーネント構成を変える必要がありそう
   - チェックボックスの状態を参照し直腸データを取得することができない 
- 都道府県数が多いためチェックボックスのgrid数を変更する必要がありそう
