### PR TITLE
feat:　人口構成のデータの種類の選択機能の実装

### DIFF
--- a/src/app/ui/DisplayConposition.tsx
+++ b/src/app/ui/DisplayConposition.tsx
@@ -6,6 +6,8 @@ import { useCheckBoxList } from "./checkbox/useCheckBox";
 import { Options } from "highcharts";
 import { useFetchWithStateData } from "./useFetchWithStateData";
 import { useChartOptions } from "./useChartOptions";
+import { useState } from "react";
+import Select from "./selectbox/Select";
 
 type Props = {
   prefs: Prefecture[];
@@ -14,6 +16,10 @@ type Props = {
 export default function DisplayComposition({ prefs }: Props) {
   const [renderCheckBoxList, checkedIdList, checkedId, checkedIndex] =
     useCheckBoxList(prefs);
+  const [selectedDataIndex, setSelectedDataIndex] = useState<number>(0);
+  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setSelectedDataIndex(parseInt(e.target.value));
+  };
   const chartData: PopulationCompositionPerYear[] = useFetchWithStateData(
     checkedId,
     checkedIndex,
@@ -22,12 +28,17 @@ export default function DisplayComposition({ prefs }: Props) {
     chartData,
     prefs,
     checkedIdList,
+    selectedDataIndex,
   );
 
   return (
     <div>
       <SelectPref renderCheckBoxList={renderCheckBoxList} />
-      {options && <Charts options={options} />}
+      <div className="w-2/3 mx-auto mt-2">
+        <h2 className="text-primary text-xl font-bold mb-2">人口構成グラフ</h2>
+        <Select select={selectedDataIndex} handleChange={handleChange} />
+        {options && <Charts options={options} />}
+      </div>
     </div>
   );
 }

--- a/src/app/ui/selectbox/Select.tsx
+++ b/src/app/ui/selectbox/Select.tsx
@@ -1,0 +1,24 @@
+type Props = {
+  select: number;
+  handleChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
+};
+
+const selectionData = ["総人口", "年少人口", "生産年齢人口", "老年人口"];
+
+export default function Select({ select, handleChange }: Props) {
+  return (
+    <select
+      className="text-black rounded-xl my-1 px-2 py-1 outline-1"
+      value={select}
+      onChange={handleChange}
+    >
+      {selectionData.map((data, index) => {
+        return (
+          <option key={data} value={index}>
+            {data}
+          </option>
+        );
+      })}
+    </select>
+  );
+}

--- a/src/app/ui/useChartOptions.tsx
+++ b/src/app/ui/useChartOptions.tsx
@@ -8,12 +8,16 @@ export const useChartOptions = (
   chartData: PopulationCompositionPerYear[],
   prefs: Prefecture[],
   checkedIdList: number[],
+  selectedDataIndex: number,
 ): Options | null => {
   const [options, setOptions] = useState<Options | null>(null);
   useEffect(() => {
     const op: Options = {
       title: {
-        text: "Chart Data",
+        text:
+          chartData.length > 0
+            ? chartData[0].data[selectedDataIndex].label
+            : "",
       },
       legend: {
         align: "right",
@@ -23,7 +27,7 @@ export const useChartOptions = (
       xAxis: {
         categories:
           chartData.length > 0
-            ? chartData[0].data[0].data.map((ele) => {
+            ? chartData[0].data[selectedDataIndex].data.map((ele) => {
                 return ele.year.toString();
               })
             : [],
@@ -44,7 +48,9 @@ export const useChartOptions = (
             type: "line",
             name: prefs[checkedIdList[index] - 1].prefName,
 
-            data: eachPrefData.data[0].data.map((ele) => ele.value),
+            data: eachPrefData.data[selectedDataIndex].data.map(
+              (ele) => ele.value,
+            ),
           };
         },
       ),
@@ -54,7 +60,7 @@ export const useChartOptions = (
     };
     setOptions(op);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [chartData]);
+  }, [chartData, selectedDataIndex]);
 
   return options;
 };


### PR DESCRIPTION
### やったこと
- データ種類を選択するコンポーネントの追加(`Selectコンポーネント`)
- `useChartOptions`内のuseEffectの依存配列に選択しているデータの種類を表す状態変数を追加し、Selectの選択肢が変化した際に再レンダリングした

### 備考
- `Select`の選択を変更しても新しいフェッチは発生しない
   - 都道府県のチェックボックスをオンにした際に全ての種類のデータをまとめてフェッチしている為