### PR TITLE
feat: レスポンシブデザインの適応

### DIFF
--- a/src/app/ui/DisplayConposition.tsx
+++ b/src/app/ui/DisplayConposition.tsx
@@ -32,9 +32,9 @@ export default function DisplayComposition({ prefs }: Props) {
   );
 
   return (
-    <div>
+    <div className="w-full md:w-2/3 md:mx-auto">
       <SelectPref renderCheckBoxList={renderCheckBoxList} />
-      <div className="w-2/3 mx-auto mt-2">
+      <div className="mt-2">
         <h2 className="text-primary text-xl font-bold mb-2">人口構成グラフ</h2>
         <Select select={selectedDataIndex} handleChange={handleChange} />
         {options && <Charts options={options} />}

--- a/src/app/ui/SelectPref.tsx
+++ b/src/app/ui/SelectPref.tsx
@@ -7,7 +7,7 @@ type Props = {
 
 export default function SelectPref({ renderCheckBoxList }: Props) {
   return (
-    <div className="w-2/3 mx-auto mt-2">
+    <div className="mt-2">
       <h2 className="text-primary text-xl font-bold mb-2">都道府県を選択</h2>
       {renderCheckBoxList()}
     </div>

--- a/src/app/ui/checkbox/CheckBoxList.tsx
+++ b/src/app/ui/checkbox/CheckBoxList.tsx
@@ -15,7 +15,7 @@ export const CheckBoxList = ({
 }: Props) => {
   return (
     <div className="flex justify-center">
-      <ul className="grid grid-cols-6 w-full gap-0.5 rounded-4xl">
+      <ul className="grid grid-cols-3 md:grid-cols-4 lg:grid-cols-6 w-full md:gap-0.5 rounded-4xl">
         {prefs.map((pref, index) => (
           <li key={index}>
             <label


### PR DESCRIPTION
### やったこと
- レスポンシブデザインの適応
   - `CheckBoxList`のグリッド数への適応
   - `DisplayComposition`コンポーネント全体のwideの調整
   - `Chart`のwideの調整 

![image](https://github.com/user-attachments/assets/4597449a-76fe-4ee6-a0d8-af2c6c840b15)

![image](https://github.com/user-attachments/assets/2ddedb5c-5ac0-4779-9e34-6c7a06a497f4)

### 備考
- `npm run test`は確認済
- グラフのlegendの位置を調整する必要あり