### PR TITLE
fix: グラフのlegendの位置を修正

### DIFF
--- a/src/app/ui/useChartOptions.tsx
+++ b/src/app/ui/useChartOptions.tsx
@@ -20,9 +20,9 @@ export const useChartOptions = (
             : "",
       },
       legend: {
-        align: "right",
-        verticalAlign: "top",
-        layout: "vertical",
+        align: "center",
+        verticalAlign: "bottom",
+        layout: "horizontal",
       },
       xAxis: {
         categories:


### PR DESCRIPTION
### やったこと
- `useChartOptions`内でグラフの`options`を変更し、`legend`の位置を右上から中央の下に修正

### 修正理由
- モバイルフォンの場合に棒グラフの値部分が非常に小さくなり過ぎてしまう為(左:before 右:after)


<img src="https://github.com/user-attachments/assets/2a7c9631-b017-40b0-984a-7c87220f3961"/>
<img src="https://github.com/user-attachments/assets/b6642b92-9c34-475f-ba71-095436031d88"/>
